### PR TITLE
Renamed python module imports to fit refactor

### DIFF
--- a/PyKEP/phasing/_lambert.py
+++ b/PyKEP/phasing/_lambert.py
@@ -1,6 +1,6 @@
 from PyGMO.problem._base import base
 from PyGMO.util import hypervolume
-from PyKEP.planets import gtoc7
+from PyKEP.planet import gtoc7
 from PyKEP.orbit_plots import plot_planet, plot_lambert
 from PyKEP.core import lambert_problem, DAY2SEC, epoch
 

--- a/PyKEP/trajopt/_mga_1dsm.py
+++ b/PyKEP/trajopt/_mga_1dsm.py
@@ -1,6 +1,6 @@
 from PyGMO.problem import base as base_problem
 from PyKEP.core import epoch, DAY2SEC, MU_SUN, lambert_problem, propagate_lagrangian, fb_prop, AU
-from PyKEP.planets import jpl_lp
+from PyKEP.planet import jpl_lp
 from math import pi, cos, sin, acos, log
 from scipy.linalg import norm
 


### PR DESCRIPTION
The refactoring done by kiryx appears to have missed two of the python examples. Running python -c "import PyKEP" on a fresh PyGMO/PyKEP install would yield an ImportError regarding the 'planets' module, which was renamed to 'planet'.