### PR TITLE
Expose reference epoch and TLE strings from tle planet objects

### DIFF
--- a/PyKEP/planet/planet.cpp
+++ b/PyKEP/planet/planet.cpp
@@ -218,7 +218,7 @@ BOOST_PYTHON_MODULE(_planet) {
 		));
 
 		planet_wrapper<planet::tle>("tle","An Earth satellite defined from the TLE format, derives from :py:class:`PyKEP.planet._base`")
-                  .def(init<optional<const std::string &, const std::string> >(
+        .def(init<optional<const std::string &, const std::string> >(
 			"PyKEP.planet.tle(line1, line2)\n\n"
 			"- line1: string containing the first line of a TLE (69 well formatted chars)\n"
 			"- line2: string containing the second line of a TLE (69 well formatted chars)\n\n"
@@ -227,7 +227,10 @@ BOOST_PYTHON_MODULE(_planet) {
 			"  line2 = '2 23177   7.0496 179.8238 7258491 296.0482   8.3061  2.25906668 97438'\n"
 			"  arianne = planet.tle(line1, line2)"
 		))
-		.def("set_epoch",&planet::tle::set_epoch,
+        .add_property("line1", &planet::tle::get_line1, "Get 1st line of original TLE")
+        .add_property("line2", &planet::tle::get_line2, "Get 2nd line of original TLE")
+        .add_property("ref_mjd2000", &planet::tle::get_ref_mjd2000, "Get reference epoch (possibly modified from what is in line 1 of TLE)");
+        .def("set_epoch",&planet::tle::set_epoch,
 		    "PyKep.planet.tle.set_epoch(year, day)\n\n"
 		    "- year: unsigned integer specifying the full 4 digit year\n"
 		    "- day:  double representing the fractional day as in TLE format.\n\n"

--- a/PyKEP/planet/planet.cpp
+++ b/PyKEP/planet/planet.cpp
@@ -229,7 +229,7 @@ BOOST_PYTHON_MODULE(_planet) {
 		))
         .add_property("line1", &planet::tle::get_line1, "Get 1st line of original TLE")
         .add_property("line2", &planet::tle::get_line2, "Get 2nd line of original TLE")
-        .add_property("ref_mjd2000", &planet::tle::get_ref_mjd2000, "Get reference epoch (possibly modified from what is in line 1 of TLE)");
+        .add_property("ref_mjd2000", &planet::tle::get_ref_mjd2000, "Get reference epoch (possibly modified from what is in line 1 of TLE)")
         .def("set_epoch",&planet::tle::set_epoch,
 		    "PyKep.planet.tle.set_epoch(year, day)\n\n"
 		    "- year: unsigned integer specifying the full 4 digit year\n"

--- a/src/planet/tle.cpp
+++ b/src/planet/tle.cpp
@@ -117,12 +117,12 @@ double tle::get_ref_mjd2000() const {
 }
 
 /// Getter for TLE line1
-double tle::get_line1() const {
+std::string tle::get_line1() const {
 	return m_line1;
 }
 
 /// Getter for TLE line2
-double tle::get_line2() const {
+std::string tle::get_line2() const {
 	return m_line2;
 }
 

--- a/src/planet/tle.cpp
+++ b/src/planet/tle.cpp
@@ -116,6 +116,16 @@ double tle::get_ref_mjd2000() const {
 	return m_ref_mjd2000;
 }
 
+/// Getter for TLE line1
+double tle::get_line1() const {
+	return m_line1;
+}
+
+/// Getter for TLE line2
+double tle::get_line2() const {
+	return m_line2;
+}
+
 /// Setter for the epoch of the TLE (workaround for 2056/2057 bug)
 void tle::set_epoch(const unsigned int year, const double day) {
     m_tle.setEpoch(year,day);

--- a/src/planet/tle.cpp
+++ b/src/planet/tle.cpp
@@ -71,12 +71,12 @@ try : base(), m_line1(line1), m_line2(line2), m_tle(Tle("TLE satellite", line1, 
 }
 catch (TleException& e)
 {
-		std::cout << "TleException cought in planet_tle constructor" << std::endl;
+		//std::cout << "TleException cought in planet_tle constructor" << std::endl;
 		throw_value_error(e.what());
 }	
 catch (SatelliteException& e)
 {
-		std::cout << "SatelliteException cought in planet_tle constructor" << std::endl;
+		//std::cout << "SatelliteException cought in planet_tle constructor" << std::endl;
 		throw_value_error(e.what());
 }
 
@@ -101,12 +101,12 @@ void tle::eph_impl(double mjd2000, array3D &r, array3D &v) const {
 	}
 	catch (SatelliteException& e)
 	{
-		std::cout << "SatelliteException caught while computing ephemerides" << std::endl;
+		//std::cout << "SatelliteException caught while computing ephemerides" << std::endl;
 		throw_value_error(e.what());
 	}
 	catch (DecayedException& e)
 	{
-		std::cout << "DecayedException caught while computing ephemerides" << std::endl;
+		//std::cout << "DecayedException caught while computing ephemerides" << std::endl;
 		throw_value_error(e.what());
 	}
 }

--- a/src/planet/tle.h
+++ b/src/planet/tle.h
@@ -33,7 +33,6 @@
 #include "../third_party/libsgp4/Tle.h"
 
 namespace kep_toolbox{ namespace planet{
-//using namespace boost::posix_time;
 
 /// A planet from TLE format
 /**
@@ -64,6 +63,9 @@ public:
 	std::string human_readable_extra() const;
 
 	double get_ref_mjd2000() const;
+	std::string get_line1() const;
+	std::string get_line2() const;
+
 	void set_epoch(const unsigned int year, const double day);
 
 private:


### PR DESCRIPTION
also silences console output in case of SGP4 related exceptions during construction or ephemeris evaluation.