### PR TITLE
Fixed equality comparator for geodetic coordinates that always returned false

### DIFF
--- a/src/third_party/libsgp4/CoordGeodetic.h
+++ b/src/third_party/libsgp4/CoordGeodetic.h
@@ -134,7 +134,7 @@ private:
     {
         bool equal = false;
         if (latitude == geo.latitude && longitude == geo.longitude && altitude == geo.altitude) {
-            equal = false;
+            equal = true;
         }
         return equal;
     }


### PR DESCRIPTION
### Bug #80: CoordGeodetic equality comparator always returns false