### PR TITLE
readme: Fix 'Build Status' badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pykep
 
 [![Join the chat at https://gitter.im/esa/pykep](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/esa/pykep?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Build Status](https://travis-ci.org/esa/pagmo.svg?branch=master)](https://travis-ci.org/esa/pykep) [![Code Health](https://landscape.io/github/esa/pykep/master/landscape.svg?style=flat)](https://landscape.io/github/esa/pykep/master)
+[![Build Status](https://api.travis-ci.org/esa/pykep.svg?branch=master)](https://travis-ci.org/esa/pykep) [![Code Health](https://landscape.io/github/esa/pykep/master/landscape.svg?style=flat)](https://landscape.io/github/esa/pykep/master)
 
 pykep is a scientific library providing basic tools for astrodynamics research. Algorithmic efficiency is
 a main focus of the library, which is written in C++ and exposed to Python using the boost::python library. At the library core


### PR DESCRIPTION
In `README.md`, the `Build Status` badge was pointing to https://travis-ci.org/esa/pagmo.svg?branch=master instead of this repository.

The build status is currently failing in the PaGMO repository, so the badge here is showing as failing as well. I've updated the link in the README to point to the correct repository (this repository), which is all green and passing, to reflect the correct status.

Before:
![Build Status](https://travis-ci.org/esa/pagmo.svg?branch=master)

After:
![Build Status](https://travis-ci.org/esa/pykep.svg?branch=master)