### PR TITLE
Fix references to GTOC

### DIFF
--- a/include/keplerian_toolbox/planet/gtoc2.hpp
+++ b/include/keplerian_toolbox/planet/gtoc2.hpp
@@ -40,7 +40,7 @@ namespace planet
  * This class allows to instantiate asteroids
  * from the Global Trajectory Optimization Competition (GTOC) 2nd edition
  *
- * @see http://www.esa.int/gsp/ACT/mad/op/GTOC/index.htm
+ * @see https://sophia.estec.esa.int/gtoc_portal/
  * @author Dario Izzo (dario.izzo _AT_ googlemail.com)
  * @author Francesco Biscani (bluescarni@gmail.com)
  */

--- a/include/keplerian_toolbox/planet/gtoc5.hpp
+++ b/include/keplerian_toolbox/planet/gtoc5.hpp
@@ -40,7 +40,7 @@ namespace planet
  * This class allows to instantiate asteroids
  * from the Global Trajectory Optimization Competition (GTOC) 5th edition
  *
- * @see http://www.esa.int/gsp/ACT/mad/op/GTOC/index.htm
+ * @see https://sophia.estec.esa.int/gtoc_portal/
  * @author Dario Izzo (dario.izzo _AT_ googlemail.com)
  * @author Francesco Biscani (bluescarni@gmail.com)
  */

--- a/include/keplerian_toolbox/planet/gtoc7.hpp
+++ b/include/keplerian_toolbox/planet/gtoc7.hpp
@@ -40,7 +40,7 @@ namespace planet
  * This class allows to instantiate main belt asteroids
  * from the Global Trajectory Optimization Competition (GTOC) 7th edition
  *
- * @see http://sophia.estec.esa.int/gtoc_portal/
+ * @see https://sophia.estec.esa.int/gtoc_portal/
  * @author Dario Izzo (dario.izzo _AT_ googlemail.com)
  */
 


### PR DESCRIPTION
The old reference (`http://www.esa.int/gsp/ACT/mad/op/GTOC/index.htm`) does not work anymore.