### PR TITLE
Correct one AU to 149597870700 m exactly

### DIFF
--- a/include/keplerian_toolbox/astro_constants.hpp
+++ b/include/keplerian_toolbox/astro_constants.hpp
@@ -43,7 +43,7 @@
 #define M_E boost::math::constants::e<double>()
 #endif
 
-#define ASTRO_AU 149597870691.0
+#define ASTRO_AU 149597870700.0
 #define ASTRO_JR 71492000.0
 #define ASTRO_MU_SUN 1.32712440018e20
 #define ASTRO_MU_EARTH 398600441800000.0

--- a/include/keplerian_toolbox/third_party/libsgp4/Globals.h
+++ b/include/keplerian_toolbox/third_party/libsgp4/Globals.h
@@ -63,7 +63,13 @@ const double kF = 1.0 / 298.26;
  * earth rotation per sideral day
  */
 const double kOMEGA_E = 1.00273790934;
-const double kAU = 1.49597870691e8;
+/* 1 AU, here given in km, per the IAU 2012 Resolution B2
+ * and the BIPM published "The International System of Units (SI), 9th ed.",
+ * Table 8 of "Non-SI units accepted for use with the SI units".
+ * Ref: https://www.iau.org/static/resolutions/IAU2012_English.pdf, accessed 2022-12-17
+ * Ref: https://www.bipm.org/documents/20126/41483022/SI-Brochure-9.pdf, accessed 2022-12-17
+ */
+const double kAU = 1.49597870700e8;
 
 const double kSECONDS_PER_DAY = 86400.0;
 const double kMINUTES_PER_DAY = 1440.0;


### PR DESCRIPTION
1 AU per the IAU 2012 Resolution B2 and the BIPM published "The International System of Units (SI), 9th ed."
Table 8 of "Non-SI units accepted for use with the SI units".

Ref: https://www.iau.org/static/resolutions/IAU2012_English.pdf, accessed 2022-12-17
Ref: https://www.bipm.org/documents/20126/41483022/SI-Brochure-9.pdf, accessed 2022-12-17

---
Please note, there is also the following lines from the NASA NAIF SPICE lib, but I leave without change here (@NASA should probably correct them upstream instead):
- https://github.com/esa/pykep/blob/6425e53f0efd74997a7ad6873791f355e2ae2e93/src/third_party/cspice/gfrfov_c.c#L581
-  https://github.com/esa/pykep/blob/6425e53f0efd74997a7ad6873791f355e2ae2e93/src/third_party/cspice/gffove.c#L1321
-  https://github.com/esa/pykep/blob/6425e53f0efd74997a7ad6873791f355e2ae2e93/src/third_party/cspice/gffove_c.c#L1180