### PR TITLE
Bump version to 3.0.1 and fix a tolerance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT CMAKE_BUILD_TYPE)
 	FORCE)
 endif()
 
-project(kep3 VERSION 3.0.0 LANGUAGES CXX C)
+project(kep3 VERSION 3.0.1 LANGUAGES CXX C)
 
 option(KEP3_VERBOSE_CONFIGURE "Enable detailed configure-time logging." OFF)
 if(KEP3_VERBOSE_CONFIGURE)

--- a/test/stm_test.cpp
+++ b/test/stm_test.cpp
@@ -135,7 +135,7 @@ TEST_CASE("propagate_lagrangian(stm)")
         auto M02 = xt::adapt(res02.second.value(), {6, 6});
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         auto M12 = xt::adapt(res12.second.value(), {6, 6});
-        REQUIRE(xt::linalg::norm(M02 - dot(M12, M01)) < 1e-13);
+        REQUIRE(xt::linalg::norm(M02 - dot(M12, M01)) < 1e-12);
     }
     { // We test the identity stm02 = stm12stm01 (hyperbolas)
         std::array<std::array<double, 3>, 2> pos_vel0 = {{{1.23, -0.12, 0.12}, {-4.12, 1.23, 0.12}}};


### PR DESCRIPTION
This pull request contains a version bump and a minor test adjustment.

- Version update:
  * Updated the project version in `CMakeLists.txt` from `3.0.0` to `3.0.1`.

- Test tolerance adjustment:
  * Relaxed the tolerance in a `REQUIRE` statement in `test/stm_test.cpp` from `1e-13` to `1e-12` to reduce test sensitivity as reprted: #198 