### PR TITLE
Enhance build system with new options and documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,40 @@
 # NOTE: current minimum kep3 requirement.
 cmake_minimum_required(VERSION 3.28.0)
-# This effectively requests behavior preferred as of a given CMake version and tells newer CMake versions to warn about their new policies.
+# This effectively requests behavior preferred as of a given CMake version and
+# tells newer CMake versions to warn about their new policies.
 cmake_policy(VERSION 3.30)
 
-# This removes a strange behaviour on osx CI machines where ninja would error out with 
-# '/bin/sh: CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS-NOTFOUND: command not found' even if clang-scan-deps was installed
-# Since we here do not use modules we deactivate their search.
+# This removes a strange behaviour on osx CI machines where ninja would error
+# out with '/bin/sh: CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS-NOTFOUND: command not
+# found' even if clang-scan-deps was installed Since we here do not use modules
+# we deactivate their search.
 set(CMAKE_CXX_SCAN_FOR_MODULES 0)
 
-# Set default build type to "Release".
-# NOTE: this should be done before the project command since the latter can set
-# CMAKE_BUILD_TYPE itself (it does so for nmake).
+# Set default build type to "Release". NOTE: this should be done before the
+# project command since the latter can set CMAKE_BUILD_TYPE itself (it does so
+# for nmake).
 if(NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE Release CACHE STRING
-		"Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
-	FORCE)
+  set(CMAKE_BUILD_TYPE
+      Release
+      CACHE
+        STRING
+        "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+        FORCE)
 endif()
 
-project(kep3 VERSION 3.0.1 LANGUAGES CXX C)
+project(
+  kep3
+  VERSION 3.0.1
+  LANGUAGES CXX C)
 
 option(KEP3_VERBOSE_CONFIGURE "Enable detailed configure-time logging." OFF)
 if(KEP3_VERBOSE_CONFIGURE)
-    # Propagate verbose messages without requiring extra CLI flags.
-    set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
+  # Propagate verbose messages without requiring extra CLI flags.
+  set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/yacma")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/yacma")
 
 # Run the YACMA compiler setup.
 include(YACMACompilerLinkerSettings)
@@ -34,25 +43,26 @@ include(YACMACompilerLinkerSettings)
 option(kep3_BUILD_TESTS "Build unit tests." OFF)
 option(kep3_BUILD_BENCHMARKS "Build benchmarks." OFF)
 option(kep3_BUILD_PYTHON_BINDINGS "Build Python bindings." OFF)
+option(kep3_BUILD_CPP_LIBRARY "Build the kep3 C++ library from source." ON)
 
-# NOTE: on Unix systems, the correct library installation path
-# could be something other than just "lib", such as "lib64",
-# "lib32", etc., depending on platform/configuration. Apparently,
-# CMake provides this information via the GNUInstallDirs module.
-# Let's enable this for now on all Unixes except OSX.
+# NOTE: on Unix systems, the correct library installation path could be
+# something other than just "lib", such as "lib64", "lib32", etc., depending on
+# platform/configuration. Apparently, CMake provides this information via the
+# GNUInstallDirs module. Let's enable this for now on all Unixes except OSX.
 # NOTE: potentially, this could be applicable to Cygwin as well.
 #
 # https://cmake.org/cmake/help/v3.15/module/GNUInstallDirs.html
 # https://cmake.org/pipermail/cmake/2013-July/055375.html
 if(UNIX AND NOT APPLE)
-    include(GNUInstallDirs)
-    set(_kep3_INSTALL_LIBDIR_DEFAULT "${CMAKE_INSTALL_LIBDIR}")
+  include(GNUInstallDirs)
+  set(_kep3_INSTALL_LIBDIR_DEFAULT "${CMAKE_INSTALL_LIBDIR}")
 else()
-    set(_kep3_INSTALL_LIBDIR_DEFAULT "lib")
+  set(_kep3_INSTALL_LIBDIR_DEFAULT "lib")
 endif()
 if(NOT kep3_INSTALL_LIBDIR)
-    set(kep3_INSTALL_LIBDIR "${_kep3_INSTALL_LIBDIR_DEFAULT}" CACHE STRING
-        "Library installation directory." FORCE)
+  set(kep3_INSTALL_LIBDIR
+      "${_kep3_INSTALL_LIBDIR_DEFAULT}"
+      CACHE STRING "Library installation directory." FORCE)
 endif()
 mark_as_advanced(kep3_INSTALL_LIBDIR)
 
@@ -60,61 +70,65 @@ mark_as_advanced(kep3_INSTALL_LIBDIR)
 set(kep3_CXX_FLAGS_DEBUG ${YACMA_CXX_FLAGS} ${YACMA_CXX_FLAGS_DEBUG})
 set(kep3_CXX_FLAGS_RELEASE ${YACMA_CXX_FLAGS})
 if(YACMA_COMPILER_IS_MSVC)
-  # On both cl and clang-cl, disable the idiotic minmax macros and enable the bigobj option.
-  # Also, enable the WIN32_LEAN_AND_MEAN definition:
+  # On both cl and clang-cl, disable the idiotic minmax macros and enable the
+  # bigobj option. Also, enable the WIN32_LEAN_AND_MEAN definition:
   # https://stackoverflow.com/questions/11040133/what-does-defining-win32-lean-and-mean-exclude-exactly
-  list(APPEND kep3_CXX_FLAGS_DEBUG "-DNOMINMAX" "/bigobj" "-DWIN32_LEAN_AND_MEAN")
-  list(APPEND kep3_CXX_FLAGS_RELEASE "-DNOMINMAX" "/bigobj" "-DWIN32_LEAN_AND_MEAN")
+  list(APPEND kep3_CXX_FLAGS_DEBUG "-DNOMINMAX" "/bigobj"
+       "-DWIN32_LEAN_AND_MEAN")
+  list(APPEND kep3_CXX_FLAGS_RELEASE "-DNOMINMAX" "/bigobj"
+       "-DWIN32_LEAN_AND_MEAN")
   if(YACMA_COMPILER_IS_CLANGXX)
-    # clang-cl emits various warnings, let's just silence them.
-    # NOTE: at one point in the recent past, MSVC added an options similar to GCC's isystem:
+    # clang-cl emits various warnings, let's just silence them. NOTE: at one
+    # point in the recent past, MSVC added an options similar to GCC's isystem:
     # https://blogs.msdn.microsoft.com/vcblog/2017/12/13/broken-warnings-theory/
-    # We probably just need to wait for this to be picked up by CMake/clang-cl. Let's
-    # revisit the issue in the future.
-    list(APPEND _kep3_CLANG_CL_DISABLED_WARNINGS
-        "-Wno-unused-variable"
-        "-Wno-inconsistent-dllimport"
-        "-Wno-unknown-pragmas"
-        "-Wno-unused-parameter"
-        "-Wno-sign-compare"
-        "-Wno-deprecated-declarations"
-        "-Wno-deprecated-dynamic-exception-spec"
-        "-Wno-old-style-cast"
-        "-Wno-sign-conversion"
-        "-Wno-non-virtual-dtor"
-        "-Wno-deprecated"
-        "-Wno-shadow"
-        "-Wno-shorten-64-to-32"
-        "-Wno-reserved-id-macro"
-        "-Wno-undef"
-        "-Wno-c++98-compat-pedantic"
-        "-Wno-documentation-unknown-command"
-        "-Wno-zero-as-null-pointer-constant"
-        "-Wno-language-extension-token"
-        "-Wno-gnu-anonymous-struct"
-        "-Wno-nested-anon-types"
-        "-Wno-documentation"
-        "-Wno-comma"
-        "-Wno-nonportable-system-include-path"
-        "-Wno-global-constructors"
-        "-Wno-redundant-parens"
-        "-Wno-exit-time-destructors"
-        "-Wno-missing-noreturn"
-        "-Wno-switch-enum"
-        "-Wno-covered-switch-default"
-        "-Wno-float-equal"
-        "-Wno-double-promotion"
-        "-Wno-microsoft-enum-value"
-        "-Wno-missing-prototypes"
-        "-Wno-implicit-fallthrough"
-        "-Wno-format-nonliteral"
-        "-Wno-cast-qual"
-        "-Wno-disabled-macro-expansion"
-        "-Wno-unused-private-field"
-        "-Wno-unused-template"
-        "-Wno-unused-macros"
-        "-Wno-extra-semi-stmt"
-        "-Wno-c++98-compat")
+    # We probably just need to wait for this to be picked up by CMake/clang-cl.
+    # Let's revisit the issue in the future.
+    list(
+      APPEND
+      _kep3_CLANG_CL_DISABLED_WARNINGS
+      "-Wno-unused-variable"
+      "-Wno-inconsistent-dllimport"
+      "-Wno-unknown-pragmas"
+      "-Wno-unused-parameter"
+      "-Wno-sign-compare"
+      "-Wno-deprecated-declarations"
+      "-Wno-deprecated-dynamic-exception-spec"
+      "-Wno-old-style-cast"
+      "-Wno-sign-conversion"
+      "-Wno-non-virtual-dtor"
+      "-Wno-deprecated"
+      "-Wno-shadow"
+      "-Wno-shorten-64-to-32"
+      "-Wno-reserved-id-macro"
+      "-Wno-undef"
+      "-Wno-c++98-compat-pedantic"
+      "-Wno-documentation-unknown-command"
+      "-Wno-zero-as-null-pointer-constant"
+      "-Wno-language-extension-token"
+      "-Wno-gnu-anonymous-struct"
+      "-Wno-nested-anon-types"
+      "-Wno-documentation"
+      "-Wno-comma"
+      "-Wno-nonportable-system-include-path"
+      "-Wno-global-constructors"
+      "-Wno-redundant-parens"
+      "-Wno-exit-time-destructors"
+      "-Wno-missing-noreturn"
+      "-Wno-switch-enum"
+      "-Wno-covered-switch-default"
+      "-Wno-float-equal"
+      "-Wno-double-promotion"
+      "-Wno-microsoft-enum-value"
+      "-Wno-missing-prototypes"
+      "-Wno-implicit-fallthrough"
+      "-Wno-format-nonliteral"
+      "-Wno-cast-qual"
+      "-Wno-disabled-macro-expansion"
+      "-Wno-unused-private-field"
+      "-Wno-unused-template"
+      "-Wno-unused-macros"
+      "-Wno-extra-semi-stmt"
+      "-Wno-c++98-compat")
     list(APPEND kep3_CXX_FLAGS_DEBUG ${_kep3_CLANG_CL_DISABLED_WARNINGS})
     list(APPEND kep3_CXX_FLAGS_RELEASE ${_kep3_CLANG_CL_DISABLED_WARNINGS})
     unset(_kep3_CLANG_CL_DISABLED_WARNINGS)
@@ -128,176 +142,221 @@ if(YACMA_COMPILER_IS_MSVC)
   check_cxx_compiler_flag("/permissive-" _kep3_MSVC_SUPPORTS_STRICT_CONFORMANCE)
   unset(CMAKE_REQUIRED_QUIET)
   if(_kep3_MSVC_SUPPORTS_STRICT_CONFORMANCE)
-        message(VERBOSE "MSVC: enabling '/permissive-' strict conformance mode.")
+    message(VERBOSE "MSVC: enabling '/permissive-' strict conformance mode.")
     list(APPEND kep3_CXX_FLAGS_DEBUG "/permissive-")
     list(APPEND kep3_CXX_FLAGS_RELEASE "/permissive-")
   endif()
   unset(_kep3_MSVC_SUPPORTS_STRICT_CONFORMANCE)
 endif()
 
-# List of source files.
-set(kep3_SRC_FILES
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/epoch.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/planet.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/lambert_problem.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/linalg.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/udpla/keplerian.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/udpla/jpl_lp.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/udpla/vsop2013.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/sims_flanagan.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/sims_flanagan_alpha.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/zoh.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/sf_checks.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/flyby.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/ic2par2ic.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/ic2mee2ic.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/mima.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/mee2par2mee.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/stm.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/propagate_lagrangian.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/encodings.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/basic_transfers.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/kep.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_kep.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_eq.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_cr3bp.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_ss.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/cr3bp.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/bcp.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/pontryagin_cartesian.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/pontryagin_equinoctial.cpp"
-)
+if(kep3_BUILD_CPP_LIBRARY)
 
-# Setup of the kep3 shared library.
-add_library(kep3 SHARED "${kep3_SRC_FILES}")
-set_property(TARGET kep3 PROPERTY VERSION ${PROJECT_VERSION})
-set_property(TARGET kep3 PROPERTY SOVERSION ${PROJECT_VERSION_MAJOR})
-set_target_properties(kep3 PROPERTIES CXX_VISIBILITY_PRESET hidden)
-set_target_properties(kep3 PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+  # List of source files.
+  set(kep3_SRC_FILES
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/epoch.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/planet.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/lambert_problem.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/linalg.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/udpla/keplerian.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/udpla/jpl_lp.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/udpla/vsop2013.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/sims_flanagan.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/sims_flanagan_alpha.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/zoh.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/leg/sf_checks.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/flyby.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/ic2par2ic.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/ic2mee2ic.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/mima.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/mee2par2mee.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/stm.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/propagate_lagrangian.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/encodings.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/core_astro/basic_transfers.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/kep.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_kep.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_eq.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_cr3bp.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/zoh_ss.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/cr3bp.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/bcp.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/pontryagin_cartesian.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/ta/pontryagin_equinoctial.cpp")
 
-# Adding this to shut down xtensor warnings (as of v0.26 still there)
-if (YACMA_COMPILER_IS_GNUCXX)
+  # Setup of the kep3 shared library.
+  add_library(kep3 SHARED "${kep3_SRC_FILES}")
+  set_property(TARGET kep3 PROPERTY VERSION ${PROJECT_VERSION})
+  set_property(TARGET kep3 PROPERTY SOVERSION ${PROJECT_VERSION_MAJOR})
+  set_target_properties(kep3 PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  set_target_properties(kep3 PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+
+  # Adding this to shut down xtensor warnings (as of v0.26 still there)
+  if(YACMA_COMPILER_IS_GNUCXX)
     target_compile_options(kep3 PRIVATE -Wno-array-bounds)
     target_compile_options(kep3 PRIVATE -Wno-stringop-overflow)
-endif()
+  endif()
 
+  target_compile_options(
+    kep3
+    PRIVATE "$<$<CONFIG:Debug>:${kep3_CXX_FLAGS_DEBUG}>"
+            "$<$<CONFIG:Release>:${kep3_CXX_FLAGS_RELEASE}>"
+            "$<$<CONFIG:RelWithDebInfo>:${kep3_CXX_FLAGS_RELEASE}>"
+            "$<$<CONFIG:MinSizeRel>:${kep3_CXX_FLAGS_RELEASE}>")
 
-target_compile_options(kep3 PRIVATE
-    "$<$<CONFIG:Debug>:${kep3_CXX_FLAGS_DEBUG}>"
-    "$<$<CONFIG:Release>:${kep3_CXX_FLAGS_RELEASE}>"
-    "$<$<CONFIG:RelWithDebInfo>:${kep3_CXX_FLAGS_RELEASE}>"
-    "$<$<CONFIG:MinSizeRel>:${kep3_CXX_FLAGS_RELEASE}>"
-)
+  # Ensure that C++23 is employed when both compiling and consuming kep3.
+  target_compile_features(kep3 PUBLIC cxx_std_23)
+  # Enforce vanilla C++23 when compiling kep3.
+  set_property(TARGET kep3 PROPERTY CXX_EXTENSIONS NO)
 
-# Ensure that C++23 is employed when both compiling and consuming kep3.
-target_compile_features(kep3 PUBLIC cxx_std_23)
-# Enforce vanilla C++23 when compiling kep3.
-set_property(TARGET kep3 PROPERTY CXX_EXTENSIONS NO)
+  target_include_directories(
+    kep3
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+           $<INSTALL_INTERFACE:include>)
+  # Boost.
+  set(_kep3_MIN_BOOST_VERSION "1.73")
+  set(_kep3_MIN_FMT_VERSION "10")
+  set(_kep3_MIN_HEYOKA_VERSION "7")
 
-target_include_directories(kep3 PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
-# Boost.
-set(_kep3_MIN_BOOST_VERSION "1.73")
-set(_kep3_MIN_FMT_VERSION "10")
-set(_kep3_MIN_HEYOKA_VERSION "7")
+  find_package(Boost ${_kep3_MIN_BOOST_VERSION} CONFIG REQUIRED
+               COMPONENTS serialization)
+  target_link_libraries(kep3 PUBLIC Boost::boost Boost::serialization)
+  # NOTE: quench warnings from Boost when building the library.
+  target_compile_definitions(kep3 PRIVATE BOOST_ALLOW_DEPRECATED_HEADERS)
 
-find_package(Boost ${_kep3_MIN_BOOST_VERSION} CONFIG REQUIRED COMPONENTS serialization)
-target_link_libraries(kep3 PUBLIC Boost::boost Boost::serialization)
-# NOTE: quench warnings from Boost when building the library.
-target_compile_definitions(kep3 PRIVATE BOOST_ALLOW_DEPRECATED_HEADERS)
+  # fmt.
+  find_package(fmt ${_kep3_MIN_FMT_VERSION} CONFIG REQUIRED)
+  target_link_libraries(kep3 PUBLIC fmt::fmt)
 
-# fmt.
-find_package(fmt ${_kep3_MIN_FMT_VERSION} CONFIG REQUIRED)
-target_link_libraries(kep3 PUBLIC fmt::fmt)
+  # heyoka.
+  find_package(heyoka ${_kep3_MIN_HEYOKA_VERSION} CONFIG REQUIRED)
+  target_link_libraries(kep3 PUBLIC heyoka::heyoka)
 
-# heyoka.
-find_package(heyoka ${_kep3_MIN_HEYOKA_VERSION} CONFIG REQUIRED)
-target_link_libraries(kep3 PUBLIC heyoka::heyoka)
+  # spdlog.
+  find_package(spdlog CONFIG REQUIRED)
+  target_link_libraries(kep3 PRIVATE spdlog::spdlog)
 
-# spdlog.
-find_package(spdlog CONFIG REQUIRED)
-target_link_libraries(kep3 PRIVATE spdlog::spdlog)
+  # xtensor.
+  find_package(xtensor CONFIG REQUIRED)
+  target_link_libraries(kep3 PRIVATE xtensor)
 
-# xtensor.
-find_package(xtensor CONFIG REQUIRED)
-target_link_libraries(kep3 PRIVATE xtensor)
+  # xtensor.
+  find_package(xtensor-blas CONFIG REQUIRED)
+  target_link_libraries(kep3 PRIVATE xtensor-blas)
 
-# xtensor.
-find_package(xtensor-blas CONFIG REQUIRED)
-target_link_libraries(kep3 PRIVATE xtensor-blas)
+  # Configure config.hpp.
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.hpp.in"
+                 "${CMAKE_CURRENT_SOURCE_DIR}/include/kep3/config.hpp" @ONLY)
 
-# Configure config.hpp.
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.hpp.in" "${CMAKE_CURRENT_SOURCE_DIR}/include/kep3/config.hpp" @ONLY)
+  # Installation of the header files.
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/kep3"
+          DESTINATION include)
+  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/kep3/config.hpp"
+          DESTINATION include/kep3)
 
-# Installation of the header files.
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/kep3" DESTINATION include)
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/kep3/config.hpp" DESTINATION include/kep3)
-
-# Installation of the library.
-install(TARGETS kep3
+  # Installation of the library.
+  install(
+    TARGETS kep3
     EXPORT kep3_export
     LIBRARY DESTINATION "${kep3_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${kep3_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION bin
-)
+    RUNTIME DESTINATION bin)
 
-include(CMakePackageConfigHelpers)
+  include(CMakePackageConfigHelpers)
 
-# Setup of the CMake config file.
-configure_package_config_file(
+  # Setup of the CMake config file.
+  configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/kep3-config.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/kep3-config.cmake"
-    INSTALL_DESTINATION "${kep3_INSTALL_LIBDIR}/cmake/kep3"
-)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kep3-config.cmake"
+    INSTALL_DESTINATION "${kep3_INSTALL_LIBDIR}/cmake/kep3")
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kep3-config.cmake"
+          DESTINATION "${kep3_INSTALL_LIBDIR}/cmake/kep3")
+  install(
+    EXPORT kep3_export
+    NAMESPACE kep3::
     DESTINATION "${kep3_INSTALL_LIBDIR}/cmake/kep3")
-install(EXPORT kep3_export NAMESPACE kep3:: DESTINATION "${kep3_INSTALL_LIBDIR}/cmake/kep3")
-# Take care of versioning.
-write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/kep3-config-version.cmake" COMPATIBILITY SameMinorVersion)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kep3-config-version.cmake" DESTINATION "${kep3_INSTALL_LIBDIR}/cmake/kep3")
+  # Take care of versioning.
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/kep3-config-version.cmake"
+    COMPATIBILITY SameMinorVersion)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kep3-config-version.cmake"
+          DESTINATION "${kep3_INSTALL_LIBDIR}/cmake/kep3")
 
+else()
+
+  # kep3 is not built from source: locate an existing installation.
+  find_package(kep3 ${PROJECT_VERSION} CONFIG)
+  if(NOT kep3_FOUND)
+    message(
+      FATAL_ERROR
+        "kep3 C++ library (version ${PROJECT_VERSION}) was not found. "
+        "Either install it first, or set kep3_BUILD_CPP_LIBRARY=ON to build it from source."
+    )
+  endif()
+
+endif()
 
 if(kep3_BUILD_TESTS)
-    enable_testing()
-    add_subdirectory(test)
+  enable_testing()
+  add_subdirectory(test)
 endif()
 
 if(kep3_BUILD_BENCHMARKS)
-    add_subdirectory(benchmark)
+  add_subdirectory(benchmark)
 
 endif()
 
 if(kep3_BUILD_PYTHON_BINDINGS)
-    # Find python
-    find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
-    message(VERBOSE "Python3 interpreter: ${Python3_EXECUTABLE}")
-    message(VERBOSE "Python3 installation directory: ${Python3_SITEARCH}")
-    message(VERBOSE "Python3 include directories: ${Python3_INCLUDE_DIRS}")
+  # Find python
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+  message(VERBOSE "Python3 interpreter: ${Python3_EXECUTABLE}")
+  message(VERBOSE "Python3 installation directory: ${Python3_SITEARCH}")
+  message(VERBOSE "Python3 include directories: ${Python3_INCLUDE_DIRS}")
 
-    set(PYKEP_INSTALL_PATH "" CACHE STRING "pykep module installation path")
-    mark_as_advanced(PYKEP_INSTALL_PATH)
+  set(PYKEP_INSTALL_PATH
+      ""
+      CACHE STRING "pykep module installation path")
+  mark_as_advanced(PYKEP_INSTALL_PATH)
 
-    # pybind11.
-    find_package(pybind11 REQUIRED)
+  # pybind11.
+  find_package(pybind11 REQUIRED)
 
-    if(MINGW OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-        message(STATUS "Creating the files for the generation of a binary wheel.")
-        set(PYKEP_VERSION ${kep3_VERSION})
-        file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/wheel")
-        configure_file("${CMAKE_CURRENT_SOURCE_DIR}/tools/wheel_setup.py" "${CMAKE_CURRENT_BINARY_DIR}/wheel/setup.py" @ONLY)
-        if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-            # NOTE: keep this Linux-only to mirror ppnf wheel generation.
-            configure_file("${CMAKE_CURRENT_SOURCE_DIR}/tools/wheel_setup.cfg" "${CMAKE_CURRENT_BINARY_DIR}/wheel/setup.cfg" @ONLY)
-        endif()
+  if(MINGW OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    message(STATUS "Creating the files for the generation of a binary wheel.")
+    set(PYKEP_VERSION ${kep3_VERSION})
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/wheel")
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/tools/wheel_setup.py"
+                   "${CMAKE_CURRENT_BINARY_DIR}/wheel/setup.py" @ONLY)
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+      # NOTE: keep this Linux-only to mirror ppnf wheel generation.
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/tools/wheel_setup.cfg"
+                     "${CMAKE_CURRENT_BINARY_DIR}/wheel/setup.cfg" @ONLY)
     endif()
+  endif()
 
-    # Build directory
-    add_subdirectory("${CMAKE_SOURCE_DIR}/pykep")
+  # Build directory
+  add_subdirectory("${CMAKE_SOURCE_DIR}/pykep")
 endif()
 
-message(STATUS "Config summary: kep3 ${kep3_VERSION} on ${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR} with ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
-message(STATUS "Config summary: build type=${CMAKE_BUILD_TYPE}, tests=${kep3_BUILD_TESTS}, benchmarks=${kep3_BUILD_BENCHMARKS}, python=${kep3_BUILD_PYTHON_BINDINGS}, verbose=${KEP3_VERBOSE_CONFIGURE}")
-message(STATUS "Config summary: install libdir=${kep3_INSTALL_LIBDIR}, deps Boost>=${_kep3_MIN_BOOST_VERSION}, fmt>=${_kep3_MIN_FMT_VERSION}, heyoka>=${_kep3_MIN_HEYOKA_VERSION}")
+if(NOT kep3_BUILD_CPP_LIBRARY
+   AND NOT kep3_BUILD_TESTS
+   AND NOT kep3_BUILD_BENCHMARKS
+   AND NOT kep3_BUILD_PYTHON_BINDINGS)
+  message(
+    STATUS
+      "Nothing to build: all build options are disabled. Enable at least one of kep3_BUILD_CPP_LIBRARY, kep3_BUILD_TESTS, kep3_BUILD_BENCHMARKS, or kep3_BUILD_PYTHON_BINDINGS."
+  )
+endif()
 
+message(
+  STATUS
+    "Config summary: kep3 ${kep3_VERSION} on ${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR} with ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}"
+)
+message(
+  STATUS
+    "Config summary: build type=${CMAKE_BUILD_TYPE}, build_kep3=${kep3_BUILD_CPP_LIBRARY}, tests=${kep3_BUILD_TESTS}, benchmarks=${kep3_BUILD_BENCHMARKS}, python=${kep3_BUILD_PYTHON_BINDINGS}, verbose=${KEP3_VERBOSE_CONFIGURE}"
+)
+message(
+  STATUS
+    "Config summary: install libdir=${kep3_INSTALL_LIBDIR}, deps Boost>=${_kep3_MIN_BOOST_VERSION}, fmt>=${_kep3_MIN_FMT_VERSION}, heyoka>=${_kep3_MIN_HEYOKA_VERSION}"
+)

--- a/README.md
+++ b/README.md
@@ -144,18 +144,22 @@ The configure step controls where `kep3` is installed, where dependencies are di
 #### Optional project flags
 
 ```cmake
--Dkep3_BUILD_TESTS=ON
--Dkep3_BUILD_BENCHMARKS=ON
--DKEP3_VERBOSE_CONFIGURE=ON
+-Dkep3_BUILD_CPP_LIBRARY
+-Dkep3_BUILD_TESTS
+-Dkep3_BUILD_BENCHMARKS
+-DKEP3_VERBOSE_CONFIGURE
 ```
 
-1. `-Dkep3_BUILD_TESTS=ON`
+1. `-Dkep3_BUILD_CPP_LIBRARY=OFF`
+   Controls whether the `kep3` C++ library is built from source (default). When set to `OFF`, CMake will instead locate an already-installed `kep3` via `find_package` and report a fatal error if it is not found. This is useful when you only want to build the Python bindings (or tests/benchmarks) against a `kep3` that has already been installed.
+
+2. `-Dkep3_BUILD_TESTS=ON`
    Builds the C++ unit-test targets.
 
-2. `-Dkep3_BUILD_BENCHMARKS=ON`
+3. `-Dkep3_BUILD_BENCHMARKS=ON`
    Builds benchmark executables under `benchmark/`.
 
-3. `-DKEP3_VERBOSE_CONFIGURE=ON`
+4. `-DKEP3_VERBOSE_CONFIGURE=ON`
    Emits additional configure-time diagnostics useful for dependency and toolchain troubleshooting.
 
 #### Common CMake build-type flag

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,18 @@
 Changelog
 #########
 
+.. _changelog_3_1_0:
+
+3.1.0 (unreleased)
+==================
+
+- Added CMake option ``kep3_BUILD_CPP_LIBRARY`` (default ``ON``). When set to
+  ``OFF``, the C++ library is not built from source and CMake will instead
+  locate an existing installation via ``find_package``. A descriptive
+  ``FATAL_ERROR`` is emitted if the library cannot be found. This makes it
+  possible to build only the Python bindings, tests, or benchmarks against an
+  already-installed ``kep3``.
+
 .. _changelog_3_0_0:
 
 3.0.0 (23-05-2026)

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -124,6 +124,10 @@ environment.
 +-------------------------------------------+----------------------------------------------------------+
 | ``-DCMAKE_PREFIX_PATH="$CONDA_PREFIX"``   | Resolve dependencies from the active conda environment.  |
 +-------------------------------------------+----------------------------------------------------------+
+| ``-Dkep3_BUILD_CPP_LIBRARY=ON``           | Build the ``kep3`` C++ library from source (default).    |
+|                                           | Set to ``OFF`` to use an already-installed ``kep3``      |
+|                                           | located via ``find_package`` instead.                    |
++-------------------------------------------+----------------------------------------------------------+
 | ``-Dkep3_BUILD_PYTHON_BINDINGS=ON``       | Build and install the ``pykep`` Python extension module. |
 +-------------------------------------------+----------------------------------------------------------+
 | ``-Dkep3_BUILD_TESTS=ON``                 | Build the C++ unit-test suite.                           |
@@ -146,11 +150,30 @@ After installation, confirm pykep is working correctly:
 
    $ python -c "import pykep; print(pykep.__version__)"
 
-To run the full test suite:
+To run the Python test suite:
 
 .. code-block:: console
 
    $ python -m pytest /path/to/pykep/tests
+
+.. rubric:: Running the C++ test suite
+
+To verify the C++ library itself, configure a build with ``kep3_BUILD_TESTS=ON``
+and run the tests via CTest:
+
+.. code-block:: console
+
+   $ cmake -S . -B build -G Ninja              \
+       -DCMAKE_PREFIX_PATH="$CONDA_PREFIX"      \
+       -Dkep3_BUILD_TESTS=ON
+   $ cmake --build build --parallel
+   $ ctest --test-dir build --output-on-failure
+
+.. note::
+
+   The ``-DCMAKE_INSTALL_PREFIX`` flag is not required when building tests
+   only — nothing is installed. CTest discovers the test executables directly
+   from the build tree.
 
 Getting help
 ============


### PR DESCRIPTION
This pull request introduces a new CMake option to control whether the `kep3` C++ library is built from source or located as a pre-installed dependency as per request #199 

**CMake build system improvements:**

* Added the `kep3_BUILD_CPP_LIBRARY` CMake option (default `ON`). When set to `OFF`, the build system will attempt to find an existing `kep3` installation instead of building the C++ library from source, emitting a clear error if not found. 
* Updated configuration summary and status messages to include the new option and improved the messaging when no build options are enabled.
* Refactored and improved CMake formatting for better readability and maintainability. 

**Documentation updates:**

* Documented the new `kep3_BUILD_CPP_LIBRARY` option in `README.md`, `doc/changelog.rst`, and `doc/installation.rst`, including usage instructions and example scenarios. 
* Added instructions for running the C++ test suite independently using CTest, clarifying the build and test process when only the tests are enabled.