### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "pykep: A research toolbox for space flight mechanics and interplanetary trajectory design"
+authors:
+  - family-names: "Izzo"
+    given-names: "Dario"
+    orcid: "https://orcid.org/0000-0002-9846-8423"
+repository-code: "https://github.com/esa/pykep"
+license: "MPL-2.0"
+version: "3.0.0"


### PR DESCRIPTION
JOSS reviewers ask for a `CITATION.cff`, and this repository does not have one yet.

Generated from the author list in `pykep/paper/paper.md`: 1 author(s), with given and family names taken from each author's ORCID record rather than split from the display name, because compound surnames do not split reliably.

`license` is `MPL-2.0`, read from the LICENSE file. `version` is `3.0.0`, the newest release tag. 

Verified with `cffconvert --validate`: valid against schema 1.2.0.