### PR TITLE
Fix knn neighbour queries for scalar and missing results

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,16 @@ Build system
 Bug fixes
 ---------
 
+- Fixed :class:`~pykep.utils.knn` nearest-neighbour queries. ``cKDTree.query``
+  returns scalar results for the default ``k=1`` and uses the size of the tree as
+  the index of a neighbour it could not find, while ``find_neighbours`` assumed
+  iterable, valid indices. A single-neighbour query therefore raised
+  ``TypeError``, and an ``IndexError`` was raised whenever fewer than ``k``
+  neighbours existed or a ``distance_upper_bound`` excluded some of them. Results
+  are now normalised to arrays and the unreachable entries dropped, so a query
+  that matches nothing returns three empty lists. Both the ``orbital`` and the
+  ``euclidean`` metrics were affected.
+
 - Fixed pickling of TOPS gym classes. The lambdas passed as ``state2cart``
   and equivalent callbacks to the internal UDP prevented serialization. They were
   replaced with :func:`functools.partial` wrapping small module-level helper

--- a/pykep/test_utils.py
+++ b/pykep/test_utils.py
@@ -65,3 +65,68 @@ class encoding_tests(_ut.TestCase):
         err = [a - b for a, b in zip(vector, vector_new)]
         err = np.linalg.norm(err)
         self.assertTrue(err < 1e-13)
+
+class knn_tests(_ut.TestCase):
+    def _planets(self):
+        import pykep as _pk
+
+        return [
+            _pk.planet(_pk.udpla.jpl_lp(name)) for name in ("earth", "mars", "venus")
+        ]
+
+    def test_single_neighbour_query(self):
+        import pykep as _pk
+
+        for metric in ("orbital", "euclidean"):
+            knn = _pk.utils.knn(self._planets(), _pk.epoch(0.0), metric=metric)
+            neighb, ids, dists = knn.find_neighbours(0)
+            self.assertEqual(len(neighb), 1)
+            self.assertEqual(len(ids), 1)
+            self.assertEqual(len(dists), 1)
+            self.assertEqual(ids[0], 0)
+            self.assertEqual(dists[0], 0.0)
+
+    def test_more_neighbours_requested_than_available(self):
+        import pykep as _pk
+
+        planets = self._planets()
+        for metric in ("orbital", "euclidean"):
+            knn = _pk.utils.knn(planets, _pk.epoch(0.0), metric=metric)
+            neighb, ids, dists = knn.find_neighbours(0, k=5)
+            self.assertEqual(len(neighb), len(planets))
+            self.assertEqual(len(ids), len(planets))
+            self.assertEqual(len(dists), len(planets))
+
+    def test_distance_upper_bound_keeps_only_reachable_neighbours(self):
+        import pykep as _pk
+
+        for metric in ("orbital", "euclidean"):
+            knn = _pk.utils.knn(self._planets(), _pk.epoch(0.0), metric=metric)
+            neighb, ids, dists = knn.find_neighbours(
+                0, k=3, distance_upper_bound=1e-10
+            )
+            self.assertEqual(len(neighb), 1)
+            self.assertEqual(ids[0], 0)
+
+    def test_no_neighbour_within_distance_upper_bound(self):
+        import pykep as _pk
+
+        outsider = _pk.planet(_pk.udpla.jpl_lp("jupiter"))
+        for metric in ("orbital", "euclidean"):
+            knn = _pk.utils.knn(self._planets(), _pk.epoch(0.0), metric=metric)
+            self.assertEqual(
+                knn.find_neighbours(outsider, k=3, distance_upper_bound=1e-10),
+                ([], [], []),
+            )
+
+    def test_nominal_query_unchanged(self):
+        import pykep as _pk
+
+        for metric in ("orbital", "euclidean"):
+            knn = _pk.utils.knn(self._planets(), _pk.epoch(0.0), metric=metric)
+            neighb, ids, dists = knn.find_neighbours(0, k=2)
+            self.assertEqual(len(neighb), 2)
+            self.assertEqual(ids[0], 0)
+
+            neighb, ids, dists = knn.find_neighbours(0, "ball", r=1e12)
+            self.assertEqual(len(neighb), 3)

--- a/pykep/utils/_knn.py
+++ b/pykep/utils/_knn.py
@@ -193,6 +193,8 @@ class knn:
             For arguments, see:
             https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.query_ball_point.html
         """
+        import numpy as np
+
         if type(query_planet) == int:
             query_planet = self._asteroids[query_planet]
 
@@ -208,6 +210,13 @@ class knn:
             # Query for the k nearest neighbors
             # http://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.query.html
             dists, idxs = self._kdtree.query(x, *args, **kwargs)
+            # A single neighbour comes back as a scalar, and a neighbour that
+            # could not be found comes back as the size of the tree.
+            idxs = np.atleast_1d(idxs)
+            dists = np.atleast_1d(dists)
+            found = idxs < len(self._asteroids)
+            idxs = idxs[found]
+            dists = dists[found]
         elif query_type == "ball":
             # Query for all neighbors within a sphere of given radius
             # http://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.query_ball_point.html


### PR DESCRIPTION
Closes #220.

## The defect

`cKDTree.query` does two things `find_neighbours` did not expect:

- with the default `k=1` it returns scalars rather than arrays, so `zip(idxs, dists)` raised `TypeError: 'int' object is not iterable`;
- a neighbour it could not find comes back with the size of the tree as its index and `inf` as its distance, so `self._asteroids[i]` raised `IndexError` as soon as fewer than `k` neighbours existed or a `distance_upper_bound` excluded some.

Reproduced on a build of master, three planets, both metrics:

| call | before |
|---|---|
| `find_neighbours(0)` | `TypeError: 'int' object is not iterable` |
| `find_neighbours(0, k=5)` | `IndexError: index 3 is out of bounds for axis 0 with size 3` |
| `find_neighbours(0, k=3, distance_upper_bound=1e-10)` | same `IndexError` |
| `find_neighbours(0, k=2)` | 2 neighbours |
| `find_neighbours(0, "ball", r=1e12)` | 3 neighbours |

## The change

The query results are normalised with `atleast_1d` and the entries whose index falls outside the planet list are dropped. The ball branch and the nominal knn branch are untouched.

## Verification

Same calls after the change, on the same build:

| call | after |
|---|---|
| `find_neighbours(0)` | 1 neighbour, the queried planet, distance 0 |
| `find_neighbours(0, k=5)` | 3 neighbours |
| `find_neighbours(0, k=3, distance_upper_bound=1e-10)` | 1 neighbour |
| a planet outside the list, `k=3, distance_upper_bound=1e-10` | `([], [], [])` |
| `find_neighbours(0, k=2)` | 2 neighbours |
| `find_neighbours(0, "ball", r=1e12)` | 3 neighbours |

Five tests added to `test_utils.py`, each run against both metrics. Four of them fail on master, the fifth pins the nominal and ball queries and passes on both sides. Full suite with the change: **99 tests, OK**, on a conda build following `tools/gha_unix_nonmanylinux.sh`.

One detail worth flagging, since the issue says three empty lists are expected there: `find_neighbours(0, k=3, distance_upper_bound=1e-10)` returns **one** neighbour rather than none. The queried planet sits at distance 0 from itself, so it is within the bound and is a legitimate match; only the two unreachable entries are dropped. The genuinely empty case needs a planet that is not in the list, and it does return `([], [], [])`. The test suite covers both.
